### PR TITLE
Allow variants on encounter generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "bybe"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["RakuJa"]
 
 # Compiler info
 edition = "2021"
-rust-version = "1.66.1"
+rust-version = "1.75.0"
 
 description = "Beyond Your Bestiary Explorer (BYBE) is a web service that provides tools to help Pathfinder 2e Game Masters."
 readme = "README.md"
@@ -21,25 +21,25 @@ publish = false
 unsafe_code = "forbid"
 
 [dependencies]
-actix-web = "4"
-actix-cors = "0.6.4"
+actix-web = "4.4.1"
+actix-cors = "0.7.0"
 actix-web-validator = "5.0.1"
 validator = {version="0.16.1", features = ["derive"]}
 
-utoipa = { version = "4", features = ["actix_extras"] }
-utoipa-swagger-ui = { version = "4", features = ["actix-web"] }
+utoipa = { version = "4.2.0", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "6.0.0", features = ["actix-web"] }
 
-sqlx = { version = "0.7.2", features = ["runtime-async-std", "sqlite"] }
-mini-moka = "0.10.2"
+sqlx = { version = "0.7.3", features = ["runtime-async-std", "sqlite"] }
+mini-moka = "0.10.3"
 
-anyhow = "1.0.75"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-strum = {version="0.25", features = ["derive"]}
+anyhow = "1.0.79"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.111"
+strum = {version="0.25.0", features = ["derive"]}
 rand = "0.8.5"
 counter = "0.5.7"
 
-env_logger = "0.10"
-log = "0.4"
+env_logger = "0.10.1"
+log = "0.4.20"
 lazy_static = "1.4.0"
-maplit = "1"
+maplit = "1.0.2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Rust project
-FROM rust:1.73-alpine as builder
+FROM rust:1.75-alpine as builder
 
 # Set the working directory in the container
 WORKDIR /app
@@ -12,15 +12,6 @@ COPY . .
 RUN apk add build-base
 
 RUN apk add musl-dev
-RUN cargo install cross
-
-# cross needs docker to work
-RUN apk add --update docker openrc
-RUN rc-update add docker boot
-
-# Static binary magic
-#RUN rustup target add aarch64-unknown-linux-musl
-#RUN rustup toolchain install stable-aarch64-unknown-linux-musl
 
 # Build the project with optimizations
 RUN cargo build --target x86_64-unknown-linux-musl --release
@@ -36,6 +27,9 @@ WORKDIR /app
 
 # Copy the built binary from the previous stage
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/bybe .
+COPY --from=builder /app/database.db .
+
+ENV DATABASE_URL="sqlite:///app/database.db"
 
 # Expose the port that your Actix-Web application will listen on
 EXPOSE 25566

--- a/src/db/db_communicator.rs
+++ b/src/db/db_communicator.rs
@@ -1,7 +1,5 @@
 use crate::models::creature::Creature;
-use crate::models::creature_metadata_enums::{
-    AlignmentEnum, CreatureTypeEnum, RarityEnum, SizeEnum,
-};
+use crate::models::creature_metadata_enums::{AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum};
 use crate::services::url_calculator::generate_archive_link;
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -80,8 +78,7 @@ async fn from_raw_to_creature(conn: &Pool<Sqlite>, raw: &RawCreature) -> Creatur
             .collect(),
         creature_type,
         archive_link,
-        is_weak: false,
-        is_elite: false,
+        variant: CreatureVariant::Base,
     }
 }
 

--- a/src/db/db_communicator.rs
+++ b/src/db/db_communicator.rs
@@ -1,5 +1,7 @@
 use crate::models::creature::Creature;
-use crate::models::creature_metadata_enums::{AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum};
+use crate::models::creature_metadata_enums::{
+    AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum,
+};
 use crate::services::url_calculator::generate_archive_link;
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -77,7 +79,8 @@ async fn from_raw_to_creature(conn: &Pool<Sqlite>, raw: &RawCreature) -> Creatur
             .map(|curr_trait| curr_trait.name)
             .collect(),
         creature_type,
-        archive_link,
+        archive_link: archive_link.clone(),
+        variant_archive_link: archive_link,
         variant: CreatureVariant::Base,
     }
 }

--- a/src/db/db_communicator.rs
+++ b/src/db/db_communicator.rs
@@ -80,6 +80,8 @@ async fn from_raw_to_creature(conn: &Pool<Sqlite>, raw: &RawCreature) -> Creatur
             .collect(),
         creature_type,
         archive_link,
+        is_weak: false,
+        is_elite: false,
     }
 }
 

--- a/src/db/db_proxy.rs
+++ b/src/db/db_proxy.rs
@@ -39,12 +39,17 @@ fn convert_creature_to_variant(creature: &Creature, level_delta: i8) -> Creature
 
     cr.level += level_delta;
 
-    cr.is_elite = level_delta >= 1;
-    cr.is_weak = level_delta <= -1;
-    if level_delta != 0 {
+    if level_delta>=1 {
+        cr.variant = CreatureVariant::Elite
+    }else if level_delta<=-1 {
+        cr.variant = CreatureVariant::Weak
+    }else {
+        cr.variant = CreatureVariant::Base
+    }
+    if cr.variant != CreatureVariant::Base {
         cr.archive_link = add_boolean_query(
             &creature.archive_link,
-            &String::from(if level_delta >= 1 { "Elite" } else { "Weak" }),
+            &String::from(cr.variant.to_string()),
             true,
         );
     }
@@ -63,7 +68,7 @@ pub async fn get_paginated_creatures(
     filters: &FieldFilters,
     pagination: &PaginatedRequest,
 ) -> Result<(u32, Vec<Creature>)> {
-    let list = get_list(app_state, CreatureVariant::Standard).await;
+    let list = get_list(app_state, CreatureVariant::Base).await;
 
     let filtered_list: Vec<Creature> = list
         .into_iter()
@@ -150,7 +155,7 @@ fn fetch_creatures_passing_single_filter(
 }
 
 pub async fn get_keys(app_state: &AppState, field: CreatureField) -> Vec<String> {
-    if let Some(db_data) = fetch_data_from_database(app_state, CreatureVariant::Standard).await {
+    if let Some(db_data) = fetch_data_from_database(app_state, CreatureVariant::Base).await {
         let runtime_fields_values = from_db_data_to_filter_cache(app_state, db_data);
         let mut x = match field {
             CreatureField::Id => runtime_fields_values.list_of_ids,

--- a/src/db/db_proxy.rs
+++ b/src/db/db_proxy.rs
@@ -39,19 +39,16 @@ fn convert_creature_to_variant(creature: &Creature, level_delta: i8) -> Creature
 
     cr.level += level_delta;
 
-    if level_delta>=1 {
+    if level_delta >= 1 {
         cr.variant = CreatureVariant::Elite
-    }else if level_delta<=-1 {
+    } else if level_delta <= -1 {
         cr.variant = CreatureVariant::Weak
-    }else {
+    } else {
         cr.variant = CreatureVariant::Base
     }
     if cr.variant != CreatureVariant::Base {
-        cr.archive_link = add_boolean_query(
-            &creature.archive_link,
-            &String::from(cr.variant.to_string()),
-            true,
-        );
+        cr.variant_archive_link =
+            add_boolean_query(&creature.archive_link, &cr.variant.to_string(), true);
     }
     cr
 }

--- a/src/models/creature.rs
+++ b/src/models/creature.rs
@@ -23,6 +23,8 @@ pub struct Creature {
     pub traits: Vec<String>,
     pub archive_link: String,
     pub creature_type: CreatureTypeEnum,
+    pub is_weak: bool,
+    pub is_elite: bool,
 }
 
 pub fn check_creature_pass_filters(creature: &Creature, filters: &FieldFilters) -> bool {

--- a/src/models/creature.rs
+++ b/src/models/creature.rs
@@ -1,6 +1,4 @@
-use crate::models::creature_metadata_enums::{
-    AlignmentEnum, CreatureTypeEnum, RarityEnum, SizeEnum,
-};
+use crate::models::creature_metadata_enums::{AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum};
 use crate::models::routers_validator_structs::FieldFilters;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -23,8 +21,7 @@ pub struct Creature {
     pub traits: Vec<String>,
     pub archive_link: String,
     pub creature_type: CreatureTypeEnum,
-    pub is_weak: bool,
-    pub is_elite: bool,
+    pub variant: CreatureVariant
 }
 
 pub fn check_creature_pass_filters(creature: &Creature, filters: &FieldFilters) -> bool {

--- a/src/models/creature.rs
+++ b/src/models/creature.rs
@@ -1,4 +1,6 @@
-use crate::models::creature_metadata_enums::{AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum};
+use crate::models::creature_metadata_enums::{
+    AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum,
+};
 use crate::models::routers_validator_structs::FieldFilters;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -20,8 +22,9 @@ pub struct Creature {
     pub sources: Vec<String>,
     pub traits: Vec<String>,
     pub archive_link: String,
+    pub variant_archive_link: String,
     pub creature_type: CreatureTypeEnum,
-    pub variant: CreatureVariant
+    pub variant: CreatureVariant,
 }
 
 pub fn check_creature_pass_filters(creature: &Creature, filters: &FieldFilters) -> bool {

--- a/src/models/creature_metadata_enums.rs
+++ b/src/models/creature_metadata_enums.rs
@@ -112,10 +112,14 @@ pub enum CreatureTypeEnum {
     Npc,
 }
 
+#[derive(
+Serialize, Deserialize, ToSchema, Display, Eq, Hash, PartialEq, Ord, PartialOrd, Default,
+)]
 pub enum CreatureVariant {
     Weak,
     Elite,
-    Standard,
+    #[default]
+    Base,
 }
 
 impl FromStr for CreatureTypeEnum {
@@ -225,7 +229,7 @@ impl Clone for CreatureVariant {
         match self {
             CreatureVariant::Elite => CreatureVariant::Elite,
             CreatureVariant::Weak => CreatureVariant::Weak,
-            CreatureVariant::Standard => CreatureVariant::Standard,
+            CreatureVariant::Base => CreatureVariant::Base,
         }
     }
 }
@@ -234,13 +238,13 @@ pub fn creature_variant_to_level_delta(creature_variant: CreatureVariant) -> i8 
     match creature_variant {
         CreatureVariant::Weak => -1,
         CreatureVariant::Elite => 1,
-        CreatureVariant::Standard => 0,
+        CreatureVariant::Base => 0,
     }
 }
 
 pub fn creature_variant_to_cache_index(creature_variant: CreatureVariant) -> i32 {
     match creature_variant {
-        CreatureVariant::Standard => 0,
+        CreatureVariant::Base => 0,
         CreatureVariant::Weak => 1,
         CreatureVariant::Elite => 2,
     }

--- a/src/models/creature_metadata_enums.rs
+++ b/src/models/creature_metadata_enums.rs
@@ -112,6 +112,12 @@ pub enum CreatureTypeEnum {
     Npc,
 }
 
+pub enum CreatureVariant {
+    Weak,
+    Elite,
+    Standard,
+}
+
 impl FromStr for CreatureTypeEnum {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -211,6 +217,32 @@ impl Clone for CreatureTypeEnum {
             CreatureTypeEnum::Monster => CreatureTypeEnum::Monster,
             CreatureTypeEnum::Npc => CreatureTypeEnum::Npc,
         }
+    }
+}
+
+impl Clone for CreatureVariant {
+    fn clone(&self) -> CreatureVariant {
+        match self {
+            CreatureVariant::Elite => CreatureVariant::Elite,
+            CreatureVariant::Weak => CreatureVariant::Weak,
+            CreatureVariant::Standard => CreatureVariant::Standard,
+        }
+    }
+}
+
+pub fn creature_variant_to_level_delta(creature_variant: CreatureVariant) -> i8 {
+    match creature_variant {
+        CreatureVariant::Weak => -1,
+        CreatureVariant::Elite => 1,
+        CreatureVariant::Standard => 0,
+    }
+}
+
+pub fn creature_variant_to_cache_index(creature_variant: CreatureVariant) -> i32 {
+    match creature_variant {
+        CreatureVariant::Standard => 0,
+        CreatureVariant::Weak => 1,
+        CreatureVariant::Elite => 2,
     }
 }
 

--- a/src/models/creature_metadata_enums.rs
+++ b/src/models/creature_metadata_enums.rs
@@ -113,7 +113,7 @@ pub enum CreatureTypeEnum {
 }
 
 #[derive(
-Serialize, Deserialize, ToSchema, Display, Eq, Hash, PartialEq, Ord, PartialOrd, Default,
+    Serialize, Deserialize, ToSchema, Display, Eq, Hash, PartialEq, Ord, PartialOrd, Default,
 )]
 pub enum CreatureVariant {
     Weak,

--- a/src/models/encounter_structs.rs
+++ b/src/models/encounter_structs.rs
@@ -29,6 +29,8 @@ pub struct RandomEncounterData {
     pub max_creatures: Option<u8>,
     #[validate(length(min = 1))]
     pub party_levels: Vec<i16>,
+    pub allow_elite_variants: Option<bool>,
+    pub allow_weak_variants: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Default, EnumIter, Eq, PartialEq, Hash, Clone)]

--- a/src/services/bestiary_service.rs
+++ b/src/services/bestiary_service.rs
@@ -1,9 +1,9 @@
 use crate::db::db_proxy;
-use crate::db::db_proxy::get_creature_by_id;
 use crate::models::creature::Creature;
 use crate::models::creature_fields_enum::CreatureField;
+use crate::models::creature_metadata_enums::CreatureVariant;
 use crate::models::routers_validator_structs::{FieldFilters, PaginatedRequest};
-use crate::services::url_calculator::{add_boolean_query, next_url_calculator};
+use crate::services::url_calculator::next_url_calculator;
 use crate::AppState;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
@@ -18,18 +18,18 @@ pub struct BestiaryResponse {
 }
 
 pub async fn get_creature(app_state: &AppState, id: i32) -> HashMap<String, Option<Creature>> {
-    hashmap! {String::from("results") => get_creature_by_id(app_state, id).await}
+    hashmap! {String::from("results") => db_proxy::get_creature_by_id(app_state, id, CreatureVariant::Standard).await}
 }
 
 pub async fn get_elite_creature(
     app_state: &AppState,
     id: i32,
 ) -> HashMap<String, Option<Creature>> {
-    hashmap! {String::from("results") => update_creature(app_state, id, 1).await}
+    hashmap! {String::from("results") => db_proxy::get_elite_creature_by_id(app_state, id).await}
 }
 
 pub async fn get_weak_creature(app_state: &AppState, id: i32) -> HashMap<String, Option<Creature>> {
-    hashmap! {String::from("results") => update_creature(app_state, id, -1).await}
+    hashmap! {String::from("results") => db_proxy::get_weak_creature_by_id(app_state, id).await}
 }
 
 pub async fn get_bestiary(
@@ -71,36 +71,6 @@ pub async fn get_alignments_list(app_state: &AppState) -> Vec<String> {
 pub async fn get_creature_types_list(app_state: &AppState) -> Vec<String> {
     db_proxy::get_keys(app_state, CreatureField::CreatureTypes).await
 }
-
-fn hp_increase_by_level() -> HashMap<i8, u16> {
-    hashmap! { 1 => 10, 2=> 15, 5=> 20, 20=> 30 }
-}
-
-async fn update_creature(app_state: &AppState, id: i32, level_delta: i8) -> Option<Creature> {
-    match get_creature_by_id(app_state, id).await {
-        Some(mut creature) => {
-            let hp_increase = hp_increase_by_level();
-            let desired_key = hp_increase
-                .keys()
-                .filter(|&&lvl| creature.level >= lvl)
-                .max()
-                .unwrap_or(hp_increase.keys().next().unwrap_or(&0));
-            creature.hp += *hp_increase.get(desired_key).unwrap_or(&0) as i16 * level_delta as i16;
-            creature.hp = creature.hp.max(1);
-
-            creature.level += level_delta;
-
-            creature.archive_link = add_boolean_query(
-                &creature.archive_link,
-                &String::from(if level_delta >= 1 { "Elite" } else { "Weak" }),
-                true,
-            );
-            Some(creature)
-        }
-        None => None,
-    }
-}
-
 fn convert_result_to_bestiary_response(
     field_filters: &FieldFilters,
     pagination: &PaginatedRequest,

--- a/src/services/bestiary_service.rs
+++ b/src/services/bestiary_service.rs
@@ -18,7 +18,7 @@ pub struct BestiaryResponse {
 }
 
 pub async fn get_creature(app_state: &AppState, id: i32) -> HashMap<String, Option<Creature>> {
-    hashmap! {String::from("results") => db_proxy::get_creature_by_id(app_state, id, CreatureVariant::Standard).await}
+    hashmap! {String::from("results") => db_proxy::get_creature_by_id(app_state, id, CreatureVariant::Base).await}
 }
 
 pub async fn get_elite_creature(

--- a/src/services/encounter_handler/encounter_calculator.rs
+++ b/src/services/encounter_handler/encounter_calculator.rs
@@ -92,7 +92,7 @@ pub fn calculate_encounter_difficulty(
 
 pub fn calculate_lvl_combination_for_encounter(
     difficulty: &EncounterChallengeEnum,
-    party_levels: &Vec<i16>,
+    party_levels: &[i16],
 ) -> (i16, HashSet<Vec<i16>>) {
     // Given an encounter difficulty it calculates all possible encounter permutations
     let exp = scale_difficulty_exp(difficulty, party_levels.len() as i16);

--- a/src/services/encounter_service.rs
+++ b/src/services/encounter_service.rs
@@ -271,8 +271,7 @@ async fn get_filtered_creatures(
     }
 
     let mut filtered_creatures =
-        fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Base)
-            .await?;
+        fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Base).await?;
 
     filtered_creatures.extend(filtered_variants);
     Ok(filtered_creatures)

--- a/src/services/encounter_service.rs
+++ b/src/services/encounter_service.rs
@@ -271,7 +271,7 @@ async fn get_filtered_creatures(
     }
 
     let mut filtered_creatures =
-        fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Standard)
+        fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Base)
             .await?;
 
     filtered_creatures.extend(filtered_variants);

--- a/src/services/encounter_service.rs
+++ b/src/services/encounter_service.rs
@@ -2,7 +2,7 @@ use crate::db::db_proxy::{fetch_creatures_passing_all_filters, order_list_by_lev
 use crate::models::creature::Creature;
 use crate::models::creature_filter_enum::CreatureFilter;
 use crate::models::creature_metadata_enums::{
-    AlignmentEnum, CreatureTypeEnum, RarityEnum, SizeEnum,
+    AlignmentEnum, CreatureTypeEnum, CreatureVariant, RarityEnum, SizeEnum,
 };
 use crate::models::encounter_structs::{
     EncounterChallengeEnum, EncounterParams, RandomEncounterData,
@@ -55,24 +55,21 @@ pub async fn generate_random_encounter(
 ) -> RandomEncounterGeneratorResponse {
     let party_levels = enc_data.party_levels.clone();
     let encounter_data = calculate_random_encounter(app_state, enc_data, party_levels).await;
-    match encounter_data {
-        Err(error) => {
-            warn!(
-                "Could not generate a random encounter, reason: {}",
-                error.to_string()
-            );
-            RandomEncounterGeneratorResponse {
-                results: None,
-                count: 0,
-                encounter_info: EncounterInfoResponse {
-                    experience: 0,
-                    challenge: Default::default(),
-                    encounter_exp_levels: Default::default(),
-                },
-            }
+    encounter_data.unwrap_or_else(|error| {
+        warn!(
+            "Could not generate a random encounter, reason: {}",
+            error.to_string()
+        );
+        RandomEncounterGeneratorResponse {
+            results: None,
+            count: 0,
+            encounter_info: EncounterInfoResponse {
+                experience: 0,
+                challenge: Default::default(),
+                encounter_exp_levels: Default::default(),
+            },
         }
-        Ok(enc_data) => enc_data,
-    }
+    })
 }
 
 // Private method, does not handle failure. For that we use a public method
@@ -110,7 +107,15 @@ async fn calculate_random_encounter(
         enc_data.creature_types,
         unique_levels,
     );
-    let filtered_creatures = fetch_creatures_passing_all_filters(app_state, filter_map).await?;
+
+    let filtered_creatures = get_filtered_creatures(
+        app_state,
+        &filter_map,
+        enc_data.allow_weak_variants,
+        enc_data.allow_elite_variants,
+    )
+    .await?;
+
     ensure!(
         !filtered_creatures.is_empty(),
         "No creatures have been fetched"
@@ -141,14 +146,9 @@ fn choose_random_creatures_combination(
     creatures_ordered_by_level
         .keys()
         .for_each(|key| list_of_levels.push(*key));
-    //let list_of_levels: Vec<i16> = filtered_creatures
-    //  .iter()
-    //.map(|curr_creature| curr_creature.level)
-    //.collect();
     let existing_levels = filter_non_existing_levels(list_of_levels, lvl_combinations);
     let tmp = Vec::from_iter(existing_levels.iter());
     let random_combo = tmp[rand::thread_rng().gen_range(0..tmp.len())];
-    // let random_combo = tmp.choose(&mut rand::thread_rng());
     // Now, having chosen the combo, we may have only x filtered creature with level y but
     // x+1 instances of level y. We need to create a vector with duplicates to fill it up to
     // the number of instances of the required level
@@ -174,14 +174,14 @@ fn choose_random_creatures_combination(
 }
 
 fn fill_vector_if_it_does_not_contain_enough_elements(
-    curr_lvl_values: &Vec<Creature>,
+    curr_lvl_values: &[Creature],
     required_number_of_creatures_with_level: usize,
 ) -> Result<Vec<Creature>> {
     ensure!(
         !curr_lvl_values.is_empty(),
         "No creatures for the chosen level"
     );
-    let mut lvl_vec = curr_lvl_values.clone();
+    let mut lvl_vec = curr_lvl_values.to_vec();
     let creature_with_required_level = lvl_vec.len();
     if creature_with_required_level < required_number_of_creatures_with_level {
         while lvl_vec.len() < required_number_of_creatures_with_level {
@@ -247,4 +247,33 @@ fn build_filter_map(
     });
     filter_map.insert(CreatureFilter::Level, lvl_combinations);
     filter_map
+}
+
+async fn get_filtered_creatures(
+    app_state: &AppState,
+    filter_map: &HashMap<CreatureFilter, HashSet<String>>,
+    allow_weak: Option<bool>,
+    allow_elite: Option<bool>,
+) -> Result<HashSet<Creature>> {
+    let mut filtered_variants = HashSet::new();
+
+    if allow_weak.is_some() && allow_weak.unwrap() {
+        filtered_variants.extend(
+            fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Weak)
+                .await?,
+        );
+    }
+    if allow_elite.is_some() && allow_elite.unwrap() {
+        filtered_variants.extend(
+            fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Elite)
+                .await?,
+        );
+    }
+
+    let mut filtered_creatures =
+        fetch_creatures_passing_all_filters(app_state, filter_map, CreatureVariant::Standard)
+            .await?;
+
+    filtered_creatures.extend(filtered_variants);
+    Ok(filtered_creatures)
 }


### PR DESCRIPTION
fix #33 

* Updated libraries
* Rust minimum compiler version is now 1.75.0
* clean up dockerfile

* split archive_url into archive_url with base url and variant_archive_url with full query
* insert into cache the elite and weak version of all creatures. It's a meh idea for performance, but it maintains a good architecture. 
* Allow the option to choose if encounter gen allows or not elite/weak variant