### PR TITLE
feat: Filter by trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Fly configuration files
+fly.toml
+dev-fly.toml
+prod-fly.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bybe"
-version = "2.1.0"
+version = "2.2.0"
 authors = ["RakuJa"]
 
 # Compiler info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,15 +25,15 @@ actix-web = "4.9.0"
 actix-cors = "0.7.0"
 validator = {version="0.18.1", features = ["derive"]}
 
-utoipa = { version = "5.0.0-alpha.2", features = ["actix_extras"] }
-utoipa-swagger-ui = { version = "7.1.1-alpha.1", features = ["actix-web"] }
+utoipa = { version = "5.0.0-beta.0", features = ["actix_extras"] }
+utoipa-swagger-ui = { version = "7.1.1-beta.0", features = ["actix-web"] }
 
-sqlx = { version = "0.8.1", features = ["runtime-async-std", "sqlite"] }
+sqlx = { version = "0.8.2", features = ["runtime-async-std", "sqlite"] }
 cached = { version = "0.53.1", features = ["async"] }
 
-anyhow = "1.0.86"
-serde = { version = "1.0.209", features = ["derive"] }
-serde_json = "1.0.127"
+anyhow = "1.0.89"
+serde = { version = "1.0.210", features = ["derive"] }
+serde_json = "1.0.128"
 strum = {version="0.26.3", features = ["derive"]}
 fastrand = "2.1.1"
 counter = "0.6.0"
@@ -52,6 +52,6 @@ once_cell = "1.19.0"
 
 [build-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "rt"] }
-anyhow = "1.0.86"
-sqlx = {version = "0.8.1", features = ["runtime-async-std", "sqlite"]}
+anyhow = "1.0.89"
+sqlx = {version = "0.8.2", features = ["runtime-async-std", "sqlite"]}
 dotenvy = "0.15.7"

--- a/src/db/data_providers/generic_fetcher.rs
+++ b/src/db/data_providers/generic_fetcher.rs
@@ -1,5 +1,6 @@
 use crate::models::item::weapon_struct::DamageData;
 use anyhow::Result;
+use itertools::Itertools;
 use sqlx::{FromRow, Pool, Sqlite};
 
 #[derive(FromRow)]
@@ -31,6 +32,7 @@ pub async fn fetch_item_traits(conn: &Pool<Sqlite>, item_id: i64) -> Result<Vec<
     .await?
     .into_iter()
     .map(|x| x.my_str)
+    .sorted()
     .collect())
 }
 
@@ -46,6 +48,7 @@ pub async fn fetch_weapon_traits(conn: &Pool<Sqlite>, weapon_id: i64) -> Result<
     .await?
     .into_iter()
     .map(|x| x.my_str)
+    .sorted()
     .collect())
 }
 
@@ -61,6 +64,7 @@ pub async fn fetch_shield_traits(conn: &Pool<Sqlite>, shield_id: i64) -> Result<
     .await?
     .into_iter()
     .map(|x| x.my_str)
+    .sorted()
     .collect())
 }
 
@@ -76,6 +80,7 @@ pub async fn fetch_armor_traits(conn: &Pool<Sqlite>, armor_id: i64) -> Result<Ve
     .await?
     .into_iter()
     .map(|x| x.my_str)
+    .sorted()
     .collect())
 }
 
@@ -91,6 +96,7 @@ pub async fn fetch_weapon_runes(conn: &Pool<Sqlite>, wp_id: i64) -> Result<Vec<S
     .await?
     .into_iter()
     .map(|x| x.my_str)
+    .sorted()
     .collect())
 }
 
@@ -118,5 +124,6 @@ pub async fn fetch_armor_runes(conn: &Pool<Sqlite>, wp_id: i64) -> Result<Vec<St
     .await?
     .into_iter()
     .map(|x| x.my_str)
+    .sorted()
     .collect())
 }

--- a/src/db/data_providers/raw_query_builder.rs
+++ b/src/db/data_providers/raw_query_builder.rs
@@ -1,50 +1,46 @@
 use crate::models::creature::creature_filter_enum::CreatureFilter;
 use crate::models::item::item_metadata::type_enum::ItemTypeEnum;
-use crate::models::shop_structs::ShopFilterQuery;
+use crate::models::shop_structs::{ItemTableFieldsFilter, ShopFilterQuery};
 use log::debug;
 use std::collections::{HashMap, HashSet};
 
 const ACCURACY_THRESHOLD: i64 = 50;
 
 pub fn prepare_filtered_get_items(shop_filter_query: &ShopFilterQuery) -> String {
-    let supported_pf_versions =
-        HashSet::from_iter(shop_filter_query.pathfinder_version.to_db_value());
-    let min_level = shop_filter_query.min_level as i64;
-    let max_level = shop_filter_query.max_level as i64;
     let equipment_query = prepare_item_subquery(
         &ItemTypeEnum::Equipment,
         shop_filter_query.n_of_equipment,
-        min_level,
-        max_level,
-        &supported_pf_versions,
+        &shop_filter_query.item_table_fields_filter,
+        shop_filter_query.trait_whitelist_filter.iter(),
+        shop_filter_query.trait_blacklist_filter.iter(),
     );
     let consumable_query = prepare_item_subquery(
         &ItemTypeEnum::Consumable,
         shop_filter_query.n_of_consumables,
-        min_level,
-        max_level,
-        &supported_pf_versions,
+        &shop_filter_query.item_table_fields_filter,
+        shop_filter_query.trait_whitelist_filter.iter(),
+        shop_filter_query.trait_blacklist_filter.iter(),
     );
     let weapon_query = prepare_item_subquery(
         &ItemTypeEnum::Weapon,
         shop_filter_query.n_of_weapons,
-        min_level,
-        max_level,
-        &supported_pf_versions,
+        &shop_filter_query.item_table_fields_filter,
+        shop_filter_query.trait_whitelist_filter.iter(),
+        shop_filter_query.trait_blacklist_filter.iter(),
     );
     let armor_query = prepare_item_subquery(
         &ItemTypeEnum::Armor,
         shop_filter_query.n_of_armors,
-        min_level,
-        max_level,
-        &supported_pf_versions,
+        &shop_filter_query.item_table_fields_filter,
+        shop_filter_query.trait_whitelist_filter.iter(),
+        shop_filter_query.trait_blacklist_filter.iter(),
     );
     let shield_query = prepare_item_subquery(
         &ItemTypeEnum::Shield,
         shop_filter_query.n_of_shields,
-        min_level,
-        max_level,
-        &supported_pf_versions,
+        &shop_filter_query.item_table_fields_filter,
+        shop_filter_query.trait_whitelist_filter.iter(),
+        shop_filter_query.trait_blacklist_filter.iter(),
     );
     let query = format!(
         "SELECT * FROM ITEM_TABLE WHERE id IN ( {equipment_query} ) OR id IN ({consumable_query} )
@@ -69,7 +65,8 @@ pub fn prepare_filtered_get_creatures_core(
                     simple_core_query.push_str(" AND ")
                 }
                 simple_core_query.push_str(
-                    prepare_in_statement_for_generic_type(key.to_string().as_str(), value).as_str(),
+                    prepare_in_statement_for_generic_type(key.to_string().as_str(), value.iter())
+                        .as_str(),
                 )
             }
             CreatureFilter::Family
@@ -81,10 +78,16 @@ pub fn prepare_filtered_get_creatures_core(
                     simple_core_query.push_str(" AND ")
                 }
                 simple_core_query.push_str(
-                    prepare_in_statement_for_string_type(key.to_string().as_str(), value).as_str(),
+                    prepare_case_insensitive_in_statement(
+                        key.to_string().as_str(),
+                        value.iter().cloned(),
+                    )
+                    .as_str(),
                 )
             }
-            CreatureFilter::Traits => trait_query.push_str(prepare_trait_filter(value).as_str()),
+            CreatureFilter::Traits => {
+                trait_query.push_str(prepare_creature_trait_filter(value.iter().cloned()).as_str())
+            }
             CreatureFilter::CreatureRoles => {
                 if !simple_core_query.is_empty() {
                     simple_core_query.push_str(" AND ")
@@ -119,8 +122,10 @@ pub fn prepare_filtered_get_creatures_core(
     query
 }
 
-/// Prepares a 'bounded OR statement' aka checks if all the columns are in the bound given
+/// Prepares a 'bounded OR statement' aka checks if all the columns are in the bound given, ex
+/// ```SQL
 /// (brute_percentage >= 0 AND brute_percentage <= 0) OR (sniper_percentage >= 0 ...) ...
+/// ```
 fn prepare_bounded_or_check(
     column_names: &HashSet<String>,
     lower_bound: i64,
@@ -143,17 +148,26 @@ fn prepare_bounded_check(column: &str, lower_bound: i64, upper_bound: i64) -> St
 }
 
 /// Prepares a query that gets all the ids linked with a given list of traits, example
+/// ```SQL
 /// SELECT tcat.creature_id
 /// FROM TRAIT_CREATURE_ASSOCIATION_TABLE tcat
 /// RIGHT JOIN
 /// (SELECT * FROM TRAIT_TABLE WHERE name IN ('good')) tt
 /// ON tcat.trait_id = tt.name GROUP BY tcat.creature_id
-///
-fn prepare_trait_filter(column_values: &HashSet<String>) -> String {
+///```
+fn prepare_trait_filter<I, S>(
+    id_column: &str,
+    association_table_name: &str,
+    column_values: I,
+) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
     let mut in_string = String::new();
-    in_string.push_str(prepare_in_statement_for_string_type("tt.name", column_values).as_str());
+    in_string.push_str(prepare_case_insensitive_in_statement("tt.name", column_values).as_str());
     if !in_string.is_empty() {
-        let select_query = "SELECT tcat.creature_id FROM TRAIT_CREATURE_ASSOCIATION_TABLE";
+        let select_query = format!("SELECT tcat.{id_column} FROM {association_table_name}");
         let inner_query = format!("SELECT * FROM TRAIT_TABLE tt WHERE {in_string}");
         return format!(
             "{select_query} tcat RIGHT JOIN ({inner_query}) jt ON tcat.trait_id = jt.name"
@@ -162,18 +176,23 @@ fn prepare_trait_filter(column_values: &HashSet<String>) -> String {
     in_string
 }
 
-/// Prepares an 'in' statement in the following format. Assuming a string value
+/// Prepares a case insensitive 'in' statement in the following format. Requires a string value in db
+/// ```SQL
 /// "UPPER(field) in (UPPER('el1'), UPPER('el2'), UPPER('el3'))"
-fn prepare_in_statement_for_string_type(
-    column_name: &str,
-    column_values: &HashSet<String>,
-) -> String {
+/// ```
+fn prepare_case_insensitive_in_statement<I, S>(column_name: &str, column_values: I) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
     let mut result_string = String::new();
-    if !column_values.is_empty() {
+    let mut x = column_values.peekable();
+    if x.peek().is_some() {
         result_string.push_str(format!("UPPER({column_name})").as_str());
         result_string.push_str(" IN (");
-        column_values.iter().for_each(|x| {
-            result_string.push_str(format!("UPPER('{x}')").as_str());
+        x.for_each(|x| {
+            let str = x.to_string();
+            result_string.push_str(format!("UPPER('{str}')").as_str());
             result_string.push(',');
         });
         if result_string.ends_with(',') {
@@ -185,17 +204,21 @@ fn prepare_in_statement_for_string_type(
 }
 
 /// Prepares an 'in' statement in the following format
+/// ```SQL
 /// 'field in (el1, el2, el3)'
-fn prepare_in_statement_for_generic_type(
-    column_name: &str,
-    column_values: &HashSet<String>,
-) -> String {
+/// ```
+fn prepare_in_statement_for_generic_type<I, S>(column_name: &str, column_values: I) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
     let mut result_string = String::new();
-    if !column_values.is_empty() {
+    let mut x = column_values.peekable();
+    if x.peek().is_some() {
         result_string.push_str(column_name);
         result_string.push_str(" IN (");
-        column_values.iter().for_each(|x| {
-            result_string.push_str(x);
+        x.for_each(|x| {
+            result_string.push_str(x.to_string().as_str());
             result_string.push(',');
         });
         if result_string.ends_with(',') {
@@ -205,21 +228,88 @@ fn prepare_in_statement_for_generic_type(
     }
     result_string
 }
-fn prepare_item_subquery(
+fn prepare_item_subquery<I, S>(
     item_type: &ItemTypeEnum,
     n_of_item: i64,
-    min_level: i64,
-    max_level: i64,
-    supported_pf_version: &HashSet<String>,
-) -> String {
+    shop_filter_vectors: &ItemTableFieldsFilter,
+    trait_whitelist_filter: I,
+    trait_blacklist_filter: I,
+) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
     let item_type_query = prepare_get_id_matching_item_type_query(item_type);
     let initial_statement = "SELECT id FROM ITEM_TABLE";
-    let filter_by_version = prepare_in_statement_for_generic_type("remaster", supported_pf_version);
-    let filter_by_level = prepare_bounded_check(&String::from("level"), min_level, max_level);
+
+    let trait_query_tmp =
+        prepare_trait_filter_statement(trait_whitelist_filter, trait_blacklist_filter);
+    let trait_query = if trait_query_tmp.is_empty() {
+        String::new()
+    } else {
+        format!("AND {trait_query_tmp}")
+    };
+    let item_fields_filter_query = prepare_item_filter_statement(shop_filter_vectors);
     format!(
-        "{initial_statement} WHERE {filter_by_level} AND {filter_by_version}
-         AND id IN ( {item_type_query} ) ORDER BY RANDOM() LIMIT {n_of_item}"
+        "{initial_statement} WHERE {item_fields_filter_query}
+         AND id IN ( {item_type_query} ) {trait_query} ORDER BY RANDOM() LIMIT {n_of_item}"
     )
+}
+
+fn prepare_item_filter_statement(shop_filter_vectors: &ItemTableFieldsFilter) -> String {
+    let remaster_query = prepare_in_statement_for_generic_type(
+        "remaster",
+        shop_filter_vectors.supported_version.iter(),
+    );
+    let filters_query = vec![
+        prepare_case_insensitive_in_statement("size", shop_filter_vectors.size_filter.iter()),
+        prepare_case_insensitive_in_statement("item_type", shop_filter_vectors.type_filter.iter()),
+        prepare_case_insensitive_in_statement(
+            "category",
+            shop_filter_vectors.category_filter.iter(),
+        ),
+        prepare_case_insensitive_in_statement("rarity", shop_filter_vectors.rarity_filter.iter()),
+        prepare_case_insensitive_in_statement("source", shop_filter_vectors.source_filter.iter()),
+        prepare_bounded_check(
+            &String::from("level"),
+            shop_filter_vectors.min_level as i64,
+            shop_filter_vectors.max_level as i64,
+        ),
+    ]
+    .into_iter()
+    .filter(|query| !query.is_empty())
+    .collect::<Vec<String>>()
+    .join(" AND ");
+    if filters_query.is_empty() {
+        remaster_query
+    } else {
+        format!("{} AND {}", remaster_query, filters_query)
+    }
+}
+
+/// Prepares an 'in' statement, with the following logic
+/// ```SQL
+/// id NOT IN (bl_id1, bl_id2, bl_idn) AND id IN (wl_id1, wl_id2, wl_idn)
+/// ```
+fn prepare_trait_filter_statement<I, S>(whitelist: I, blacklist: I) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
+    let whitelist_query = prepare_item_trait_filter(whitelist);
+    let blacklist_query = prepare_item_trait_filter(blacklist);
+    if whitelist_query.is_empty() && blacklist_query.is_empty() {
+        String::new()
+    } else if whitelist_query.is_empty() {
+        format!("id NOT IN ({})", blacklist_query)
+    } else if blacklist_query.is_empty() {
+        format!("id IN ({})", whitelist_query)
+    } else {
+        format!(
+            "id IN ({}) AND id NOT IN ({})",
+            whitelist_query, blacklist_query
+        )
+    }
 }
 
 fn prepare_get_id_matching_item_type_query(item_type: &ItemTypeEnum) -> String {
@@ -247,4 +337,40 @@ fn prepare_get_id_matching_item_type_query(item_type: &ItemTypeEnum) -> String {
         item_type.to_db_main_table_name(),
         item_type.to_db_association_table_name(),
     )
+}
+
+/// Prepares a query that gets all the ids linked with a given list of traits, example
+/// ```SQL
+/// SELECT tcat.creature_id
+/// FROM TRAIT_CREATURE_ASSOCIATION_TABLE tcat
+/// RIGHT JOIN
+/// (SELECT * FROM TRAIT_TABLE WHERE name IN ('good')) tt
+/// ON tcat.trait_id = tt.name GROUP BY tcat.creature_id
+///```
+fn prepare_creature_trait_filter<I, S>(column_values: I) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
+    prepare_trait_filter(
+        "creature_id",
+        "TRAIT_CREATURE_ASSOCIATION_TABLE",
+        column_values,
+    )
+}
+
+/// Prepares a query that gets all the ids linked with a given list of traits, example
+/// ```SQL
+/// SELECT tcat.item_id
+/// FROM TRAIT_ITEM_ASSOCIATION_TABLE tcat
+/// RIGHT JOIN
+/// (SELECT * FROM TRAIT_TABLE WHERE name IN ('good')) tt
+/// ON tcat.trait_id = tt.name GROUP BY tcat.item_id
+///```
+fn prepare_item_trait_filter<I, S>(column_values: I) -> String
+where
+    I: Iterator<Item = S>,
+    S: ToString,
+{
+    prepare_trait_filter("item_id", "TRAIT_ITEM_ASSOCIATION_TABLE", column_values)
 }

--- a/src/db/data_providers/shop_fetcher.rs
+++ b/src/db/data_providers/shop_fetcher.rs
@@ -262,7 +262,12 @@ pub async fn fetch_items_with_filters(
         .filter(|x| x.item_type == ItemTypeEnum::Consumable)
         .collect();
 
-    if items.len() as i64 >= filters.n_of_consumables + filters.n_of_equipment {
+    let n_of_items_to_return = filters.n_of_equipment
+        + filters.n_of_shields
+        + filters.n_of_weapons
+        + filters.n_of_armors
+        + filters.n_of_consumables;
+    if items.len() as i64 >= n_of_items_to_return {
         debug!("Result vector is the correct size, no more operations needed");
         return Ok(items);
     }

--- a/src/db/shop_proxy.rs
+++ b/src/db/shop_proxy.rs
@@ -48,6 +48,7 @@ pub async fn get_paginated_items(
             ItemSortEnum::Id => a.core_item.id.cmp(&b.core_item.id),
             ItemSortEnum::Name => a.core_item.name.cmp(&b.core_item.name),
             ItemSortEnum::Level => a.core_item.level.cmp(&b.core_item.level),
+            ItemSortEnum::Trait => a.core_item.traits.cmp(&b.core_item.traits),
             ItemSortEnum::Type => a.core_item.item_type.cmp(&b.core_item.item_type),
             ItemSortEnum::Rarity => a.core_item.rarity.cmp(&b.core_item.rarity),
             ItemSortEnum::Source => a.core_item.source.cmp(&b.core_item.source),
@@ -141,6 +142,7 @@ pub async fn get_all_sources(app_state: &AppState) -> Vec<String> {
             .map(|x| x.source)
             .unique()
             .filter(|x| !x.is_empty())
+            .sorted()
             .collect(),
         Err(_) => {
             vec![]
@@ -165,6 +167,7 @@ pub async fn get_all_traits(app_state: &AppState) -> Vec<String> {
             .flat_map(|x| x.traits)
             .unique()
             .filter(|x| !x.is_empty())
+            .sorted()
             .collect(),
         _ => {
             vec![]

--- a/src/db/shop_proxy.rs
+++ b/src/db/shop_proxy.rs
@@ -147,3 +147,19 @@ pub async fn get_all_sources(app_state: &AppState) -> Vec<String> {
         }
     }
 }
+
+/// Gets all the runtime traits. It will cache the result
+#[once(sync_writes = true)]
+pub async fn get_all_traits(app_state: &AppState) -> Vec<String> {
+    match get_all_items_from_db(app_state).await {
+        Ok(v) => v
+            .into_iter()
+            .flat_map(|x| x.traits)
+            .unique()
+            .filter(|x| !x.is_empty())
+            .collect(),
+        Err(_) => {
+            vec![]
+        }
+    }
+}

--- a/src/db/shop_proxy.rs
+++ b/src/db/shop_proxy.rs
@@ -151,14 +151,22 @@ pub async fn get_all_sources(app_state: &AppState) -> Vec<String> {
 /// Gets all the runtime traits. It will cache the result
 #[once(sync_writes = true)]
 pub async fn get_all_traits(app_state: &AppState) -> Vec<String> {
-    match get_all_items_from_db(app_state).await {
-        Ok(v) => v
+    match (
+        get_all_items_from_db(app_state).await,
+        get_all_weapons_from_db(app_state).await,
+        get_all_armors_from_db(app_state).await,
+        get_all_shields_from_db(app_state).await,
+    ) {
+        (Ok(items), Ok(wps), Ok(armors), Ok(shields)) => items
             .into_iter()
+            .chain(wps.into_iter().map(|x| x.item_core))
+            .chain(armors.into_iter().map(|x| x.item_core))
+            .chain(shields.into_iter().map(|x| x.item_core))
             .flat_map(|x| x.traits)
             .unique()
             .filter(|x| !x.is_empty())
             .collect(),
-        Err(_) => {
+        _ => {
             vec![]
         }
     }

--- a/src/models/item/item_struct.rs
+++ b/src/models/item/item_struct.rs
@@ -172,6 +172,22 @@ impl Item {
                     .to_lowercase()
                     .contains(source.to_lowercase().as_str())
             })
+        }) && filters.trait_whitelist_filter.as_ref().map_or(true, |x| {
+            x.iter().any(|filter_trait| {
+                self.traits.iter().any(|item_trait| {
+                    item_trait
+                        .to_lowercase()
+                        .contains(filter_trait.to_lowercase().as_str())
+                })
+            })
+        }) && !filters.trait_blacklist_filter.as_ref().map_or(false, |x| {
+            x.iter().any(|filter_trait| {
+                self.traits.iter().any(|item_trait| {
+                    item_trait
+                        .to_lowercase()
+                        .eq(filter_trait.to_lowercase().as_str())
+                })
+            })
         })
     }
 }

--- a/src/models/routers_validator_structs.rs
+++ b/src/models/routers_validator_structs.rs
@@ -41,6 +41,8 @@ pub struct ItemFieldFilters {
     pub name_filter: Option<String>,
     pub category_filter: Option<Vec<String>>,
     pub source_filter: Option<Vec<String>>,
+    pub trait_whitelist_filter: Option<Vec<String>>,
+    pub trait_blacklist_filter: Option<Vec<String>>,
 
     #[validate(range(min = 0.))]
     pub min_bulk_filter: Option<f64>,
@@ -58,7 +60,7 @@ pub struct ItemFieldFilters {
     pub min_level_filter: Option<i64>,
     #[validate(range(min = -1))]
     pub max_level_filter: Option<i64>,
-    #[validate(range(min = -1))]
+    #[validate(range(min = 0))]
     pub min_price_filter: Option<i64>,
     #[validate(range(min = 0))]
     pub max_price_filter: Option<i64>,

--- a/src/models/shop_structs.rs
+++ b/src/models/shop_structs.rs
@@ -1,5 +1,8 @@
+use crate::models::item::item_metadata::type_enum::ItemTypeEnum;
 use crate::models::pf_version_enum::PathfinderVersionEnum;
 use crate::models::routers_validator_structs::{Dice, OrderEnum, PaginatedRequest};
+use crate::models::shared::rarity_enum::RarityEnum;
+use crate::models::shared::size_enum::SizeEnum;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter};
 use utoipa::{IntoParams, ToSchema};
@@ -17,6 +20,14 @@ pub enum ShopTemplateEnum {
 
 #[derive(Serialize, Deserialize, ToSchema, Validate, Clone)]
 pub struct RandomShopData {
+    pub category_filter: Option<Vec<String>>,
+    pub source_filter: Option<Vec<String>>,
+    pub trait_whitelist_filter: Option<Vec<String>>,
+    pub trait_blacklist_filter: Option<Vec<String>>,
+    pub type_filter: Option<Vec<ItemTypeEnum>>,
+    pub rarity_filter: Option<Vec<RarityEnum>>,
+    pub size_filter: Option<Vec<SizeEnum>>,
+
     #[validate(range(max = 30))]
     pub min_level: Option<u8>,
     #[validate(range(max = 30))]
@@ -29,16 +40,27 @@ pub struct RandomShopData {
     pub pathfinder_version: Option<PathfinderVersionEnum>,
 }
 
-pub struct ShopFilterQuery {
-    //pub shop_type: ShopTypeEnum,
+pub struct ItemTableFieldsFilter {
+    pub category_filter: Vec<String>,
+    pub source_filter: Vec<String>,
+    pub type_filter: Vec<ItemTypeEnum>,
+    pub rarity_filter: Vec<RarityEnum>,
+    pub size_filter: Vec<SizeEnum>,
+    pub supported_version: Vec<String>,
+
     pub min_level: u8,
     pub max_level: u8,
+}
+
+pub struct ShopFilterQuery {
+    pub item_table_fields_filter: ItemTableFieldsFilter,
+    pub trait_whitelist_filter: Vec<String>,
+    pub trait_blacklist_filter: Vec<String>,
     pub n_of_equipment: i64,
     pub n_of_consumables: i64,
     pub n_of_weapons: i64,
     pub n_of_armors: i64,
     pub n_of_shields: i64,
-    pub pathfinder_version: PathfinderVersionEnum,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Default, Eq, PartialEq, Hash, Clone, Display)]

--- a/src/models/shop_structs.rs
+++ b/src/models/shop_structs.rs
@@ -72,6 +72,8 @@ pub enum ItemSortEnum {
     Name,
     #[serde(alias = "level", alias = "LEVEL")]
     Level,
+    #[serde(alias = "trait", alias = "TRAIT")]
+    Trait,
     #[serde(alias = "type", alias = "TYPE")]
     Type,
     #[serde(alias = "rarity", alias = "RARITY")]

--- a/src/routes/shop.rs
+++ b/src/routes/shop.rs
@@ -23,6 +23,7 @@ pub fn init_endpoints(cfg: &mut web::ServiceConfig) {
         web::scope("/shop")
             .service(get_item)
             .service(get_shop_listing)
+            .service(get_traits_list)
             .service(get_sources_list)
             .service(get_random_shop_listing),
     );
@@ -31,7 +32,13 @@ pub fn init_endpoints(cfg: &mut web::ServiceConfig) {
 pub fn init_docs(doc: &mut utoipa::openapi::OpenApi) {
     #[derive(OpenApi)]
     #[openapi(
-        paths(get_shop_listing, get_item, get_random_shop_listing, get_sources_list),
+        paths(
+            get_shop_listing,
+            get_item,
+            get_random_shop_listing,
+            get_traits_list,
+            get_sources_list
+        ),
         components(schemas(
             ResponseItem,
             ItemTypeEnum,
@@ -153,6 +160,23 @@ pub async fn get_item(
 #[get("/sources")]
 pub async fn get_sources_list(data: web::Data<AppState>) -> actix_web::Result<impl Responder> {
     Ok(web::Json(shop_service::get_sources_list(&data).await))
+}
+
+#[utoipa::path(
+    get,
+    path = "/shop/traits",
+    tag = "shop",
+    params(
+
+    ),
+    responses(
+        (status=200, description = "Successful Response", body = [String]),
+        (status=400, description = "Bad request.")
+    ),
+)]
+#[get("/traits")]
+pub async fn get_traits_list(data: web::Data<AppState>) -> actix_web::Result<impl Responder> {
+    Ok(web::Json(shop_service::get_traits_list(&data).await))
 }
 
 fn sanitize_id(creature_id: &str) -> actix_web::Result<i64> {

--- a/src/routes/shop.rs
+++ b/src/routes/shop.rs
@@ -23,8 +23,8 @@ pub fn init_endpoints(cfg: &mut web::ServiceConfig) {
         web::scope("/shop")
             .service(get_item)
             .service(get_shop_listing)
-            .service(get_traits_list)
-            .service(get_sources_list)
+            .service(get_items_traits_list)
+            .service(get_items_sources_list)
             .service(get_random_shop_listing),
     );
 }
@@ -36,8 +36,8 @@ pub fn init_docs(doc: &mut utoipa::openapi::OpenApi) {
             get_shop_listing,
             get_item,
             get_random_shop_listing,
-            get_traits_list,
-            get_sources_list
+            get_items_traits_list,
+            get_items_sources_list
         ),
         components(schemas(
             ResponseItem,
@@ -158,7 +158,9 @@ pub async fn get_item(
     ),
 )]
 #[get("/sources")]
-pub async fn get_sources_list(data: web::Data<AppState>) -> actix_web::Result<impl Responder> {
+pub async fn get_items_sources_list(
+    data: web::Data<AppState>,
+) -> actix_web::Result<impl Responder> {
     Ok(web::Json(shop_service::get_sources_list(&data).await))
 }
 
@@ -175,7 +177,7 @@ pub async fn get_sources_list(data: web::Data<AppState>) -> actix_web::Result<im
     ),
 )]
 #[get("/traits")]
-pub async fn get_traits_list(data: web::Data<AppState>) -> actix_web::Result<impl Responder> {
+pub async fn get_items_traits_list(data: web::Data<AppState>) -> actix_web::Result<impl Responder> {
     Ok(web::Json(shop_service::get_traits_list(&data).await))
 }
 


### PR DESCRIPTION
Update dependencies, order alphabetically every trait query (they are not ordered by default). 
Add item trait (both blacklist and whitelist), updating query generation and endpoints. 
Move from passing Vec to generic Iterators with items that implement ToString trait. This improves both usability (now we  can call those methods with both hashsets and vec) and also performances avoiding useless clones since the .iter() method does not take ownership of the data.